### PR TITLE
Apply black formatting to dc_make and common/tools

### DIFF
--- a/common/tools.py
+++ b/common/tools.py
@@ -1,112 +1,149 @@
 import math
 import numpy as np
 
-class PackageWrapper:
-  def __init__(self, import_fn):
-    self._package = None
-    self._import_fn = import_fn
 
-  def __getattr__(self, name):
-    if self._package is None:
-      self._package = self._import_fn()
-    return getattr(self._package, name)
+class PackageWrapper:
+    def __init__(self, import_fn):
+        self._package = None
+        self._import_fn = import_fn
+
+    def __getattr__(self, name):
+        if self._package is None:
+            self._package = self._import_fn()
+        return getattr(self._package, name)
+
 
 def lazyImport(package_name):
-  def import_fn():
-    return __import__(package_name)
-  return PackageWrapper(import_fn)
+    def import_fn():
+        return __import__(package_name)
+
+    return PackageWrapper(import_fn)
+
 
 def importROOT():
-  def import_fn():
-    import ROOT
-    ROOT.gROOT.SetBatch(True)
-    ROOT.gROOT.SetMustClean(False)
-    ROOT.TH1.AddDirectory(False)
-    ROOT.TH2.AddDirectory(False)
-    ROOT.EnableThreadSafety()
-    return ROOT
-  return PackageWrapper(import_fn)
+    def import_fn():
+        import ROOT
+
+        ROOT.gROOT.SetBatch(True)
+        ROOT.gROOT.SetMustClean(False)
+        ROOT.TH1.AddDirectory(False)
+        ROOT.TH2.AddDirectory(False)
+        ROOT.EnableThreadSafety()
+        return ROOT
+
+    return PackageWrapper(import_fn)
+
 
 ROOT = importROOT()
 
+
 def listToVector(x, value_type):
-  v = ROOT.std.vector(value_type)(len(x))
-  for n in range(len(x)):
-    v[n] = x[n]
-  return v
+    v = ROOT.std.vector(value_type)(len(x))
+    for n in range(len(x)):
+        v[n] = x[n]
+    return v
+
 
 def rebinAndFill(new_hist, old_hist, epsilon=1e-7):
-  def check_range(old_axis, new_axis):
-    old_min = old_axis.GetBinLowEdge(1)
-    old_max = old_axis.GetBinUpEdge(old_axis.GetNbins())
-    new_min = new_axis.GetBinLowEdge(1)
-    new_max = new_axis.GetBinUpEdge(new_axis.GetNbins())
-    return old_min <= new_min and old_max >= new_max
+    def check_range(old_axis, new_axis):
+        old_min = old_axis.GetBinLowEdge(1)
+        old_max = old_axis.GetBinUpEdge(old_axis.GetNbins())
+        new_min = new_axis.GetBinLowEdge(1)
+        new_max = new_axis.GetBinUpEdge(new_axis.GetNbins())
+        return old_min <= new_min and old_max >= new_max
 
-  def get_new_bin(old_axis, new_axis, bin_id_old):
-    old_low_edge = round(old_axis.GetBinLowEdge(bin_id_old), 4)
-    old_up_edge = round(old_axis.GetBinUpEdge(bin_id_old), 4)
-    bin_low_new = new_axis.FindFixBin(old_low_edge)
-    bin_up_new = new_axis.FindFixBin(old_up_edge)
+    def get_new_bin(old_axis, new_axis, bin_id_old):
+        old_low_edge = round(old_axis.GetBinLowEdge(bin_id_old), 4)
+        old_up_edge = round(old_axis.GetBinUpEdge(bin_id_old), 4)
+        bin_low_new = new_axis.FindFixBin(old_low_edge)
+        bin_up_new = new_axis.FindFixBin(old_up_edge)
 
-    new_up_edge = new_axis.GetBinUpEdge(bin_low_new)
-    if not (bin_low_new == bin_up_new or \
-            abs(old_up_edge - new_up_edge) <= epsilon * abs(old_up_edge + new_up_edge) * 2):
-      old_bins = [ str(old_axis.GetBinLowEdge(n)) for n in range(1, old_axis.GetNbins() + 2)]
-      new_bins = [ str(new_axis.GetBinLowEdge(n)) for n in range(1, new_axis.GetNbins() + 2)]
-      print('old_bins: [{}]'.format(', '.join(old_bins)))
-      print('new_bins: [{}]'.format(', '.join(new_bins)))
+        new_up_edge = new_axis.GetBinUpEdge(bin_low_new)
+        if not (
+            bin_low_new == bin_up_new
+            or abs(old_up_edge - new_up_edge)
+            <= epsilon * abs(old_up_edge + new_up_edge) * 2
+        ):
+            old_bins = [
+                str(old_axis.GetBinLowEdge(n))
+                for n in range(1, old_axis.GetNbins() + 2)
+            ]
+            new_bins = [
+                str(new_axis.GetBinLowEdge(n))
+                for n in range(1, new_axis.GetNbins() + 2)
+            ]
+            print("old_bins: [{}]".format(", ".join(old_bins)))
+            print("new_bins: [{}]".format(", ".join(new_bins)))
 
-      raise RuntimeError("Incompatible bin edges")
-    return bin_low_new
+            raise RuntimeError("Incompatible bin edges")
+        return bin_low_new
 
-  def add_bin_content(bin_old, bin_new):
-    cnt_old = old_hist.GetBinContent(bin_old)
-    err_old = old_hist.GetBinError(bin_old)
-    cnt_new = new_hist.GetBinContent(bin_new)
-    err_new = new_hist.GetBinError(bin_new)
-    cnt_upd = cnt_new + cnt_old
-    err_upd = math.sqrt(err_new ** 2 + err_old ** 2)
-    new_hist.SetBinContent(bin_new, cnt_upd)
-    new_hist.SetBinError(bin_new, err_upd);
+    def add_bin_content(bin_old, bin_new):
+        cnt_old = old_hist.GetBinContent(bin_old)
+        err_old = old_hist.GetBinError(bin_old)
+        cnt_new = new_hist.GetBinContent(bin_new)
+        err_new = new_hist.GetBinError(bin_new)
+        cnt_upd = cnt_new + cnt_old
+        err_upd = math.sqrt(err_new**2 + err_old**2)
+        new_hist.SetBinContent(bin_new, cnt_upd)
+        new_hist.SetBinError(bin_new, err_upd)
 
-  n_dim = old_hist.GetDimension()
-  if new_hist.GetDimension() != n_dim:
-    raise RuntimeError("Incompatible number of dimensions")
-  if n_dim < 1 or n_dim > 2:
-    raise RuntimeError("Unsupported number of dimensions")
+    n_dim = old_hist.GetDimension()
+    if new_hist.GetDimension() != n_dim:
+        raise RuntimeError("Incompatible number of dimensions")
+    if n_dim < 1 or n_dim > 2:
+        raise RuntimeError("Unsupported number of dimensions")
 
-  if not check_range(old_hist.GetXaxis(), new_hist.GetXaxis()):
-    raise RuntimeError("x ranges are not compatible")
+    if not check_range(old_hist.GetXaxis(), new_hist.GetXaxis()):
+        raise RuntimeError("x ranges are not compatible")
 
-  if n_dim > 1 and not check_range(old_hist.GetYaxis(), new_hist.GetYaxis()):
-    raise RuntimeError("y ranges are not compatible")
+    if n_dim > 1 and not check_range(old_hist.GetYaxis(), new_hist.GetYaxis()):
+        raise RuntimeError("y ranges are not compatible")
 
-  for x_bin_old in range(old_hist.GetNbinsX() + 2):
-    x_bin_new = get_new_bin(old_hist.GetXaxis(), new_hist.GetXaxis(), x_bin_old)
-    if n_dim == 1:
-      add_bin_content(x_bin_old, x_bin_new)
-    else:
-      for y_bin_old in range(old_hist.GetNbinsY() + 2):
-        y_bin_new = get_new_bin(old_hist.GetYaxis(), new_hist.GetYaxis(), y_bin_old)
-        bin_old = old_hist.GetBin(x_bin_old, y_bin_old)
-        bin_new = new_hist.GetBin(x_bin_new, y_bin_new)
-        add_bin_content(bin_old, bin_new)
+    for x_bin_old in range(old_hist.GetNbinsX() + 2):
+        x_bin_new = get_new_bin(old_hist.GetXaxis(), new_hist.GetXaxis(), x_bin_old)
+        if n_dim == 1:
+            add_bin_content(x_bin_old, x_bin_new)
+        else:
+            for y_bin_old in range(old_hist.GetNbinsY() + 2):
+                y_bin_new = get_new_bin(
+                    old_hist.GetYaxis(), new_hist.GetYaxis(), y_bin_old
+                )
+                bin_old = old_hist.GetBin(x_bin_old, y_bin_old)
+                bin_new = new_hist.GetBin(x_bin_new, y_bin_new)
+                add_bin_content(bin_old, bin_new)
 
 
-def getRelevantBins(era, channel, category,signal_processes_histograms,signalFractionForRelevantBins,unc_name=None, unc_scale=None, model_params=None):
+def getRelevantBins(
+    era,
+    channel,
+    category,
+    signal_processes_histograms,
+    signalFractionForRelevantBins,
+    unc_name=None,
+    unc_scale=None,
+    model_params=None,
+):
     relevant_bins = set()
     for hist in signal_processes_histograms:
         axis = hist.GetXaxis()
-        hist_integral = hist.Integral(1,axis.GetNbins() + 1)
-        for nbin in range(1,axis.GetNbins() + 1):
-          if hist_integral !=0 and hist.GetBinContent(nbin) / hist_integral >= signalFractionForRelevantBins:
-            relevant_bins.add(nbin)
+        hist_integral = hist.Integral(1, axis.GetNbins() + 1)
+        for nbin in range(1, axis.GetNbins() + 1):
+            if (
+                hist_integral != 0
+                and hist.GetBinContent(nbin) / hist_integral
+                >= signalFractionForRelevantBins
+            ):
+                relevant_bins.add(nbin)
     return list(relevant_bins)
 
 
 def th1ToNumpy(histogram, include_overflow=False):
-    bin_range = (0, histogram.GetNbinsX() + 1) if include_overflow else (1, histogram.GetNbinsX())
+    bin_range = (
+        (0, histogram.GetNbinsX() + 1)
+        if include_overflow
+        else (1, histogram.GetNbinsX())
+    )
     n_bins = bin_range[1] - bin_range[0] + 1
     bin_contents = np.zeros(n_bins)
     bin_errors = np.zeros(n_bins)
@@ -119,6 +156,7 @@ def th1ToNumpy(histogram, include_overflow=False):
         bin_indices[bin_number] = bin_idx
     return bin_indices, bin_numbers, bin_contents, bin_errors
 
+
 class NegativeBinSolution:
     def __init__(self):
         self.accepted = True
@@ -130,11 +168,20 @@ class NegativeBinSolution:
         self.relevant_negative_bins = set()
         self.changed_bins = set()
 
-def resolveNegativeBins(histogram, allow_zero_integral=False, allow_negative_integral=False,
-                        allow_negative_bins_within_error=False, max_n_sigma_for_negative_bins=1,
-                        relevant_bins=None, include_overflow=False):
+
+def resolveNegativeBins(
+    histogram,
+    allow_zero_integral=False,
+    allow_negative_integral=False,
+    allow_negative_bins_within_error=False,
+    max_n_sigma_for_negative_bins=1,
+    relevant_bins=None,
+    include_overflow=False,
+):
     relevant_bins = relevant_bins or []
-    bin_indices, bin_numbers, bin_contents, bin_errors = th1ToNumpy(histogram, include_overflow)
+    bin_indices, bin_numbers, bin_contents, bin_errors = th1ToNumpy(
+        histogram, include_overflow
+    )
     n_bins = len(bin_numbers)
 
     solution = NegativeBinSolution()
@@ -142,16 +189,16 @@ def resolveNegativeBins(histogram, allow_zero_integral=False, allow_negative_int
     if solution.integral == 0:
         solution.has_zero_integral = True
         solution.accepted = allow_zero_integral
-        #print("integral = 0")
+        # print("integral = 0")
         return solution
     if solution.integral < 0:
         solution.has_negative_integral = True
         solution.accepted = allow_negative_integral
-        #print("integral < 0")
+        # print("integral < 0")
         return solution
 
-    donor_integral = 0.
-    negative_integral = 0.
+    donor_integral = 0.0
+    negative_integral = 0.0
 
     for bin_idx in range(n_bins):
         if bin_contents[bin_idx] >= 0:
@@ -160,8 +207,11 @@ def resolveNegativeBins(histogram, allow_zero_integral=False, allow_negative_int
             continue
         negative_integral += bin_contents[bin_idx]
         solution.negative_bins.add(bin_numbers[bin_idx])
-        #print(bin_idx, bin_numbers[bin_idx])
-        zero_within_error = bin_contents[bin_idx] + max_n_sigma_for_negative_bins * bin_errors[bin_idx] >= 0
+        # print(bin_idx, bin_numbers[bin_idx])
+        zero_within_error = (
+            bin_contents[bin_idx] + max_n_sigma_for_negative_bins * bin_errors[bin_idx]
+            >= 0
+        )
         if zero_within_error:
             solution.negative_bins_within_error.add(bin_numbers[bin_idx])
         if not allow_negative_bins_within_error or not zero_within_error:
@@ -174,30 +224,44 @@ def resolveNegativeBins(histogram, allow_zero_integral=False, allow_negative_int
         solution.accepted = False
 
     if not solution.accepted or len(solution.negative_bins) == 0:
-        #print("solution not accepted or len solution(negative bins) = 0")
+        # print("solution not accepted or len solution(negative bins) = 0")
         return solution
 
     for bin_number in solution.negative_bins:
         bin_idx = bin_indices[bin_number]
         donor_bin_indices = []
         for i in range(n_bins):
-            if i != bin_idx and bin_numbers[i] not in relevant_bins and bin_contents[i] > 0:
+            if (
+                i != bin_idx
+                and bin_numbers[i] not in relevant_bins
+                and bin_contents[i] > 0
+            ):
                 donor_bin_indices.append(i)
-        donor_bin_indices = sorted(donor_bin_indices, key=lambda i: abs(i-bin_idx))
+        donor_bin_indices = sorted(donor_bin_indices, key=lambda i: abs(i - bin_idx))
         to_balance = -bin_contents[bin_idx]
-        bin_errors[bin_idx] = math.sqrt(bin_contents[bin_idx] ** 2 + bin_errors[bin_idx] ** 2)
+        bin_errors[bin_idx] = math.sqrt(
+            bin_contents[bin_idx] ** 2 + bin_errors[bin_idx] ** 2
+        )
         bin_contents[bin_idx] = 0
         solution.changed_bins.add(bin_number)
         for donor_bin_idx in donor_bin_indices:
             donor_contribution = min(to_balance, bin_contents[donor_bin_idx])
-            if donor_contribution <= 0: continue
-            bin_errors[donor_bin_idx] = math.sqrt(donor_contribution ** 2 + bin_errors[donor_bin_idx] ** 2)
+            if donor_contribution <= 0:
+                continue
+            bin_errors[donor_bin_idx] = math.sqrt(
+                donor_contribution**2 + bin_errors[donor_bin_idx] ** 2
+            )
             bin_contents[donor_bin_idx] -= donor_contribution
             solution.changed_bins.add(bin_numbers[donor_bin_idx])
             to_balance -= donor_contribution
-            if to_balance <= 0: break
-        if to_balance > 0: # this should not happen, because we checked that negative_integral <= donor_integral
-            raise RuntimeError(f"resolveNegativeBins: failed to balance bin {bin_number}")
+            if to_balance <= 0:
+                break
+        if (
+            to_balance > 0
+        ):  # this should not happen, because we checked that negative_integral <= donor_integral
+            raise RuntimeError(
+                f"resolveNegativeBins: failed to balance bin {bin_number}"
+            )
     for bin_number in solution.changed_bins:
         bin_idx = bin_indices[bin_number]
         histogram.SetBinContent(int(bin_number), bin_contents[bin_idx])

--- a/dc_make/create_datacards.py
+++ b/dc_make/create_datacards.py
@@ -3,43 +3,71 @@ import sys
 import json
 
 if __name__ == "__main__":
-  file_dir = os.path.dirname(os.path.abspath(__file__))
-  pkg_dir = os.path.dirname(file_dir)
-  base_dir = os.path.dirname(pkg_dir)
-  pkg_dir_name = os.path.split(pkg_dir)[1]
-  if base_dir not in sys.path:
-    sys.path.append(base_dir)
-  __package__ = pkg_dir_name
+    file_dir = os.path.dirname(os.path.abspath(__file__))
+    pkg_dir = os.path.dirname(file_dir)
+    base_dir = os.path.dirname(pkg_dir)
+    pkg_dir_name = os.path.split(pkg_dir)[1]
+    if base_dir not in sys.path:
+        sys.path.append(base_dir)
+    __package__ = pkg_dir_name
 
 from StatInference.dc_make.maker import DatacardMaker
 
 if __name__ == "__main__":
-  import argparse
-  parser = argparse.ArgumentParser(description='Create datacards.')
-  parser.add_argument('--input', required=True, type=str, help="input directory")
-  parser.add_argument('--output', required=True, type=str, help="output directory")
-  parser.add_argument('--config', required=True, type=str, help="configuration file")
-  parser.add_argument('--hist-bins', required=False, type=str, default=None, help="bin edges to rebin histograms")
-  parser.add_argument('--param_values', required=False, type=str, default=None, help="parameter values to run only certain masses")
+    import argparse
 
-  for param in DatacardMaker.customizeble_parameters:
-    parser.add_argument(f'--{param}', required=False, type=str, default=None, help=f"custom value for {param}")
+    parser = argparse.ArgumentParser(description="Create datacards.")
+    parser.add_argument("--input", required=True, type=str, help="input directory")
+    parser.add_argument("--output", required=True, type=str, help="output directory")
+    parser.add_argument("--config", required=True, type=str, help="configuration file")
+    parser.add_argument(
+        "--hist-bins",
+        required=False,
+        type=str,
+        default=None,
+        help="bin edges to rebin histograms",
+    )
+    parser.add_argument(
+        "--param_values",
+        required=False,
+        type=str,
+        default=None,
+        help="parameter values to run only certain masses",
+    )
 
-  args = parser.parse_args()
+    for param in DatacardMaker.customizeble_parameters:
+        parser.add_argument(
+            f"--{param}",
+            required=False,
+            type=str,
+            default=None,
+            help=f"custom value for {param}",
+        )
 
-  if args.hist_bins is not None:
-    if args.hist_bins.endswith(".json"): hist_bins = args.hist_bins
+    args = parser.parse_args()
+
+    if args.hist_bins is not None:
+        if args.hist_bins.endswith(".json"):
+            hist_bins = args.hist_bins
+        else:
+            hist_bins = [float(x) for x in args.hist_bins.split(",")]
     else:
-      hist_bins = [ float(x) for x in args.hist_bins.split(',') ]
-  else:
-    hist_bins = None
+        hist_bins = None
 
-  if args.param_values is not None:
-    param_values = [ int(x) for x in args.param_values.split(',') ]
-  else:
-    param_values = None
+    if args.param_values is not None:
+        param_values = [int(x) for x in args.param_values.split(",")]
+    else:
+        param_values = None
 
-  kwargs = { param: getattr(args, param) for param in DatacardMaker.customizeble_parameters }
+    kwargs = {
+        param: getattr(args, param) for param in DatacardMaker.customizeble_parameters
+    }
 
-  maker = DatacardMaker(args.config, args.input, hist_bins=hist_bins, param_values=param_values, **kwargs)
-  maker.createDatacards(args.output)
+    maker = DatacardMaker(
+        args.config,
+        args.input,
+        hist_bins=hist_bins,
+        param_values=param_values,
+        **kwargs,
+    )
+    maker.createDatacards(args.output)

--- a/dc_make/maker.py
+++ b/dc_make/maker.py
@@ -5,462 +5,659 @@ import yaml
 
 from CombineHarvester.CombineTools.ch import CombineHarvester
 
-from StatInference.common.tools import listToVector, rebinAndFill, importROOT, resolveNegativeBins, getRelevantBins
+from StatInference.common.tools import (
+    listToVector,
+    rebinAndFill,
+    importROOT,
+    resolveNegativeBins,
+    getRelevantBins,
+)
 from .process import Process
-from .uncertainty import Uncertainty, UncertaintyType, UncertaintyScale, MultiValueLnNUncertainty
+from .uncertainty import (
+    Uncertainty,
+    UncertaintyType,
+    UncertaintyScale,
+    MultiValueLnNUncertainty,
+)
 from .model import Model
 from .binner import Binner
+
 ROOT = importROOT()
 
 
 class DatacardMaker:
-  customizeble_parameters = ["eras", "channels", "categories"]
+    customizeble_parameters = ["eras", "channels", "categories"]
 
-  def __init__(self, cfg_file, input_path, hist_bins=None, param_values=None, **kwargs):
-    self.cb = CombineHarvester()
+    def __init__(
+        self, cfg_file, input_path, hist_bins=None, param_values=None, **kwargs
+    ):
+        self.cb = CombineHarvester()
 
-    self.input_path = input_path
-    with open(cfg_file, 'r') as f:
-      cfg = yaml.safe_load(f)
-    for param in self.customizeble_parameters:
-      if param not in kwargs: continue
-      value = kwargs[param]
-      if value is None: continue
-      value_type = type(cfg[param])
-      if value_type == list:
-        value = value.split(',')
-      else:
-        value = value_type(value)
-      print(f"Overriding config parameter {param} to {value}")
-      cfg[param] = value
-
-    self.analysis = cfg["analysis"]
-    self.eras = cfg["eras"]
-    self.channels = cfg["channels"]
-    self.categories = cfg["categories"]
-    self.signalFractionForRelevantBins = cfg['signalFractionForRelevantBins']
-
-
-    self.bins = []
-    for era, channel, cat in self.ECC():
-      bin = self.getBin(era, channel, cat, return_index=False)
-      self.bins.append(bin)
-
-    self.model = Model.fromConfig(cfg["model"])
-    self.keep_all_signal_hypothesis_into_single_datacard = cfg.get("keep_all_signal_hypothesis_into_single_datacard", False)
-    self.param_bins = {}
-    self.processes = {}
-    self.param_of = {}
-    self.base_of = {}
-    data_process = None
-    has_signal = False
-    self.channel_processes = {}
-    for channel in self.channels:
-      self.channel_processes[channel] = []
-
-    for process in cfg["processes"]:
-      if (type(process) != str) and process.get('is_signal', False):
-        if param_values is not None:
-          print(f"Overwriting signal parameters to {param_values}")
-          process['param_values'] = param_values
-      new_processes = Process.fromConfig(process, self.model)
-      for process in new_processes:
-        if process.name in self.processes:
-          raise RuntimeError(f"Process name {process.name} already exists")
-        print(f"Adding {process}")
-        self.processes[process.name] = process
-        if process.channels:
-          for channel in process.channels:
-            if channel not in self.channel_processes:
-              print(f"Channel {channel} not defined in config")
-              continue
-            self.channel_processes[channel].append(process.name)
-        else:
-          for channel in self.channels:
-            self.channel_processes[channel].append(process.name)
-        if process.is_data:
-          if data_process is not None:
-            raise RuntimeError("Multiple data processes defined")
-          data_process = process
-        if process.is_signal:
-          has_signal = True
-          self.param_bins.setdefault(self.model.paramStr(process.params), process.params)
-    if data_process is None:
-      raise RuntimeError("No data process defined")
-    if not has_signal:
-      raise RuntimeError("No signal process defined")
-
-    self.uncertainties = {}
-    for unc_entry in cfg["uncertainties"]:
-      unc = Uncertainty.fromConfig(unc_entry)
-      if unc.name in self.uncertainties:
-        raise RuntimeError(f"Uncertainty {unc.name} already exists")
-      self.uncertainties[unc.name] = unc
-
-    self.autolnNThr = cfg.get("autolnNThr", 0.05)
-    self.asymlnNThr = cfg.get("asymlnNThr", 0.001)
-    self.ignorelnNThr = cfg.get("ignorelnNThr", 0.001)
-
-    self.autoMCStats = cfg.get("autoMCStats", { 'apply': False })
-
-
-    hist_bins = hist_bins or cfg.get("hist_bins", None)
-    self.hist_binner = Binner(hist_bins)
-    # print(f"Using hist_bins: {self.hist_binner.hist_bins}")
-
-    self.input_files = {}
-    self.shapes = {}
-    self.signal_hists_by_key = {}
-
-
-  def getBin(self, era, channel, category, return_name=True, return_index=True):
-    name = f'{era}_{self.analysis}_{channel}_{category}'
-    if not return_name and not return_index:
-      raise RuntimeError("Invalid argument combination")
-    if not return_index:
-      return name
-    index = self.bins.index(name)
-    if not return_name:
-      return index
-    return (index, name)
-
-  def cbCopy(self, param_str, process, era, channel, category):
-    bin_idx, bin_name = self.getBin(era, channel, category)
-    return self.cb.cp().mass([param_str]).process([process]).bin([bin_name])
-
-  def ECC(self):
-    return itertools.product(self.eras, self.channels, self.categories)
-
-  def PPECC(self):
-    param_bins = list(self.param_bins.keys())
-    if not self.model.param_dependent_bkg:
-      param_bins.append("*")
-    return itertools.product(self.processes.keys(), param_bins, self.eras, self.channels, self.categories)
-
-  def getInputFile(self, era, model_params):
-    file_name = self.model.getInputFileName(era, model_params)
-    if file_name not in self.input_files:
-      full_file_name = os.path.join(self.input_path, file_name)
-      file = ROOT.TFile.Open(full_file_name, "READ")
-      if file == None:
-        raise RuntimeError(f"Cannot open file {full_file_name}")
-      self.input_files[file_name] = file
-    return file_name, self.input_files[file_name]
-
-
-  def getMultiValueLnUnc(self,unc,unc_name, process, era, channel, category, model_params):#, unc_name=None, unc_scale=None)
-    file_name, file = self.getInputFile(era, model_params)
-    hist_name = f"{channel}/{category}/{process.hist_name}"
-    if unc.getUncertaintyForProcess(process.name) != None:
-      return unc.getUncertaintyForProcess(process.name)
-    elif process.subprocesses:
-      unc_value_tot_down = 0.
-      unc_value_tot_up = 0.
-      yield_value_tot = 0.
-      for subp in process.subprocesses:
-        hist_name = f"{channel}/{category}/{subp}"
-        subhist = file.Get(hist_name)
-        #newhist = self.hist_binner.applyBinning(era, channel, category, model_params, subhist)
-        if subhist == None:
-          raise RuntimeError(f"Cannot find histogram {hist_name} in {file.GetName()}")
-        axis = subhist.GetXaxis()
-        yield_subproc = subhist.Integral(1,axis.GetNbins() + 1)
-        unc_value = unc.getUncertaintyForProcess(subp)
-        if unc_value != None:
-          if yield_subproc == 0 : continue
-          # print(unc_value)
-          if isinstance(unc_value, dict):
-            unc_value_tot_up += unc_value[UncertaintyScale.Up]*yield_subproc
-            unc_value_tot_down += unc_value[UncertaintyScale.Down]*yield_subproc
-          else:
-            unc_value_tot_up += unc_value*yield_subproc
-            unc_value_tot_down -= unc_value*yield_subproc
-          yield_value_tot+=yield_subproc
-      if unc_value_tot_up != 0. and unc_value_tot_down !=0 :
-        return {UncertaintyScale.Down: unc_value_tot_down/yield_value_tot, UncertaintyScale.Up: unc_value_tot_up/yield_value_tot}
-      return None
-    return None
-
-
-  def getShape(self, process, era, channel, category, model_params, unc_name=None, unc_scale=None):
-    file_name, file = self.getInputFile(era, model_params)
-    key = (file_name, process.name, era, channel, category, unc_name, unc_scale)
-    if key not in self.shapes:
-      if process.is_data and (unc_name is not None or unc_scale is not None):
-        raise RuntimeError("Cannot apply uncertainty to the data process")
-      if process.is_asimov_data:
-        hist = None
-        for bkg_proc in self.processes.values():
-          if bkg_proc.is_background:
-            if bkg_proc.name not in self.channel_processes[channel]:
-              continue
-            bkg_hist = self.getShape(bkg_proc, era, channel, category, model_params)
-            if hist is None:
-              hist = bkg_hist.Clone()
+        self.input_path = input_path
+        with open(cfg_file, "r") as f:
+            cfg = yaml.safe_load(f)
+        for param in self.customizeble_parameters:
+            if param not in kwargs:
+                continue
+            value = kwargs[param]
+            if value is None:
+                continue
+            value_type = type(cfg[param])
+            if value_type == list:
+                value = value.split(",")
             else:
-              hist.Add(bkg_hist)
-        if hist is None:
-          raise RuntimeError("Cannot create asimov data histogram")
-      else:
-        hist_name = f"{channel}/{category}/{process.hist_name}"
-        hists = []
-        if process.subprocesses:
-          for subp in process.subprocesses:
-            hist_name = f"{channel}/{category}/{subp}"
-            if unc_name and unc_scale:
-              hist_name += f"_{unc_name}_{unc_scale}"
-            subhist = file.Get(hist_name)
-            if subhist == None:
-              raise RuntimeError(f"Cannot find histogram {hist_name} in {file.GetName()}")
-            hists.append(self.hist_binner.applyBinning(era, channel, category, model_params, subhist))
-        else:
-          if unc_name and unc_scale:
-            hist_name += f"_{unc_name}_{unc_scale}"
-          hist = file.Get(hist_name)
-          if hist == None:
-            raise RuntimeError(f"Cannot find histogram {hist_name} in {file.GetName()}")
-          hists.append(self.hist_binner.applyBinning(era, channel, category, model_params, hist))
-        if len(hists) == 0:
-          raise RuntimeError(f"hist list is empty for file {file.GetName()}")
-        hist = hists[0]
-        if len(hists)>1:
-          for histy in hists[1:]:
-            hist.Add(histy)
+                value = value_type(value)
+            print(f"Overriding config parameter {param} to {value}")
+            cfg[param] = value
 
-        hist.SetDirectory(0)
-        if process.scale != 1:
-          hist.Scale(process.scale)
+        self.analysis = cfg["analysis"]
+        self.eras = cfg["eras"]
+        self.channels = cfg["channels"]
+        self.categories = cfg["categories"]
+        self.signalFractionForRelevantBins = cfg["signalFractionForRelevantBins"]
 
-        if process.is_signal and not (unc_name and unc_scale):
-            param_str = self.model.paramStr(model_params) if model_params else '*'
-            key_sig = (era, channel, category, param_str if not self.keep_all_signal_hypothesis_into_single_datacard else '*')
-            self.signal_hists_by_key.setdefault(key_sig, []).append(hist)
-        else:
-          param_str = self.model.paramStr(model_params) if model_params else '*'
-          key_sig = (era, channel, category, param_str if not self.keep_all_signal_hypothesis_into_single_datacard else '*')
-          signals = self.signal_hists_by_key.get(key_sig, [])
-          relevant_bins = getRelevantBins(era, channel, category, signals, self.signalFractionForRelevantBins)
-          solution = resolveNegativeBins(hist,relevant_bins=relevant_bins,allow_zero_integral=process.allow_zero_integral,allow_negative_bins_within_error=process.allow_negative_bins_within_error,max_n_sigma_for_negative_bins=process.max_n_sigma_for_negative_bins,allow_negative_integral=process.allow_negative_integral)
+        self.bins = []
+        for era, channel, cat in self.ECC():
+            bin = self.getBin(era, channel, cat, return_index=False)
+            self.bins.append(bin)
 
-          if not solution.accepted:
-            axis = hist.GetXaxis()
-            bins_edges = [ str(axis.GetBinLowEdge(n)) for n in range(1, axis.GetNbins() + 2)]
-            bin_values = [ str(hist.GetBinContent(n)) for n in range(1, axis.GetNbins() + 1)]
-            bin_errors = [ str(hist.GetBinError(n)) for n in range(1, axis.GetNbins() + 1)]
-            print(f'bins_edges: [ {", ".join(bins_edges)} ]')
-            print(f'bin_values: [ {", ".join(bin_values)} ]')
-            print(f'bin_errors: [ {", ".join(bin_errors)} ]')
-            raise RuntimeError(
-                f"Negative bins found in histogram for {channel}/{category}/{process.hist_name}"
-                + (f" (syst {unc_name}{unc_scale})" if unc_name and unc_scale else "")
-            )
-      self.shapes[key] = hist
-    return self.shapes[key]
+        self.model = Model.fromConfig(cfg["model"])
+        self.keep_all_signal_hypothesis_into_single_datacard = cfg.get(
+            "keep_all_signal_hypothesis_into_single_datacard", False
+        )
+        self.param_bins = {}
+        self.processes = {}
+        self.param_of = {}
+        self.base_of = {}
+        data_process = None
+        has_signal = False
+        self.channel_processes = {}
+        for channel in self.channels:
+            self.channel_processes[channel] = []
 
-
-
-
-  def addProcess(self, proc, era, channel, category):
-    bin_idx, bin_name = self.getBin(era, channel, category)
-    process = self.processes[proc]
-    def add(model_params, param_str, process_name):
-      if process.is_data:
-        self.cb.AddObservations([param_str], [self.analysis], [era], [channel], [(bin_idx, bin_name)])
-      else:
-        self.cb.AddProcesses([param_str], [self.analysis], [era], [channel], [process_name], [(bin_idx, bin_name)], process.is_signal)
-
-      shape = self.getShape(process, era, channel, category, model_params)
-      shape_set = False
-      def setShape(p):
-        nonlocal shape_set
-        print(f"Setting shape for {p}")
-        if shape_set:
-          raise RuntimeError("Shape already set")
-        p.set_shape(shape, True)
-        shape_set = True
-      cb_copy = self.cbCopy(param_str, process_name, era, channel, category)
-      if process.is_data:
-        cb_copy.ForEachObs(setShape)
-      else:
-        cb_copy.ForEachProc(setShape)
-
-    if process.is_signal:
-      model_params = process.params
-      param_str = self.model.paramStr(model_params)
-      if self.keep_all_signal_hypothesis_into_single_datacard:
-        actual_proc_name = f"{process.name}_{param_str}"
-        add(model_params, '*', actual_proc_name)
-        self.param_of[('*', actual_proc_name)] = model_params
-        self.base_of[actual_proc_name] = process.name
-      else:
-        actual_proc_name = process.name
-        add(model_params, param_str, actual_proc_name)
-        self.param_of[(param_str, actual_proc_name)] = model_params
-        self.base_of[actual_proc_name] = process.name
-
-
-    elif self.model.param_dependent_bkg:
-      for signal_proc in self.processes.values():
-        if not signal_proc.is_signal: continue
-        model_params = signal_proc.params
-        param_str = self.model.paramStr(model_params) if not self.keep_all_signal_hypothesis_into_single_datacard else '*'
-        add(model_params, param_str, proc)
-        self.param_of[(param_str, proc)] = model_params
-        self.base_of[proc] = proc
-    else:
-      add(None, "*", proc)
-
-  def addUncertainty(self, unc_name):
-    unc = self.uncertainties[unc_name]
-    isMVLnUnc = isinstance(unc, MultiValueLnNUncertainty)
-
-    for proc, param_str, era, channel, category in self.PPECC():
-      if proc not in self.channel_processes[channel]:
-        continue
-      process = self.processes[proc]
-      if process.is_data: continue
-      model_params = self.param_bins.get(param_str, None)
-      if isMVLnUnc:
-        unc_value = self.getMultiValueLnUnc(unc,unc_name,process, era, channel, category, model_params)#, unc_name=None, unc_scale=None
-
-      uncApplies = unc_value != None if isMVLnUnc else unc.appliesTo(process, era, channel, category)
-      if not uncApplies: continue
-      if not process.hasCompatibleModelParams(model_params, self.model.param_dependent_bkg): continue
-
-
-      nominal_shape = None
-      shapes = {}
-      if unc.needShapes:
-        model_params = self.param_bins.get(param_str, None)
-        nominal_shape = self.getShape(self.processes[proc], era, channel, category, model_params)
-
-
-        for unc_scale in [ UncertaintyScale.Up, UncertaintyScale.Down ]:
-          shapes[unc_scale] = self.getShape(self.processes[proc], era, channel, category, model_params,
-                                            unc_name, unc_scale.name)
-
-      unc_to_apply = unc.resolveType(nominal_shape, shapes, self.autolnNThr, self.asymlnNThr)
-      can_ignore = unc_to_apply.canIgnore(unc_value, self.ignorelnNThr) if isMVLnUnc else unc_to_apply.canIgnore(self.ignorelnNThr)
-      if can_ignore:
-        print(f"Ignoring uncertainty {unc_name} for {proc} in {era} {channel} {category}")
-        continue
-      systMap = unc_to_apply.valueToMap(unc_value) if isMVLnUnc else unc_to_apply.valueToMap()
-      cb_copy = self.cbCopy(param_str, proc, era, channel, category)
-      cb_copy.AddSyst(self.cb, unc_name, unc_to_apply.type.name, systMap)
-      if unc_to_apply.type == UncertaintyType.shape:
-        shape_set = False
-        def setShape(syst):
-          nonlocal shape_set
-          print(f"Setting unc shape for {syst}")
-          if shape_set:
-            raise RuntimeError("Shape already set")
-          syst.set_shapes(shapes[UncertaintyScale.Up], shapes[UncertaintyScale.Down], nominal_shape)
-          shape_set = True
-        self.cbCopy(param_str, proc, era, channel, category).syst_name([unc_name]).ForEachSyst(setShape)
-
-    if self.keep_all_signal_hypothesis_into_single_datacard:
-        for (param_str, proc_name), params in self.param_of.items():
-            for era, channel, category in self.ECC():
-                base_name = self.base_of.get(proc_name, proc_name)
-                process = self.processes[base_name]
+        for process in cfg["processes"]:
+            if (type(process) != str) and process.get("is_signal", False):
+                if param_values is not None:
+                    print(f"Overwriting signal parameters to {param_values}")
+                    process["param_values"] = param_values
+            new_processes = Process.fromConfig(process, self.model)
+            for process in new_processes:
+                if process.name in self.processes:
+                    raise RuntimeError(f"Process name {process.name} already exists")
+                print(f"Adding {process}")
+                self.processes[process.name] = process
+                if process.channels:
+                    for channel in process.channels:
+                        if channel not in self.channel_processes:
+                            print(f"Channel {channel} not defined in config")
+                            continue
+                        self.channel_processes[channel].append(process.name)
+                else:
+                    for channel in self.channels:
+                        self.channel_processes[channel].append(process.name)
                 if process.is_data:
-                    continue
-
-                if isMVLnUnc:
-                    unc_value = self.getMultiValueLnUnc(
-                        unc, unc_name, process, era, channel, category, params
+                    if data_process is not None:
+                        raise RuntimeError("Multiple data processes defined")
+                    data_process = process
+                if process.is_signal:
+                    has_signal = True
+                    self.param_bins.setdefault(
+                        self.model.paramStr(process.params), process.params
                     )
-                uncApplies = (unc_value is not None) if isMVLnUnc else unc.appliesTo(process, era, channel, category)
-                if not uncApplies:
+        if data_process is None:
+            raise RuntimeError("No data process defined")
+        if not has_signal:
+            raise RuntimeError("No signal process defined")
+
+        self.uncertainties = {}
+        for unc_entry in cfg["uncertainties"]:
+            unc = Uncertainty.fromConfig(unc_entry)
+            if unc.name in self.uncertainties:
+                raise RuntimeError(f"Uncertainty {unc.name} already exists")
+            self.uncertainties[unc.name] = unc
+
+        self.autolnNThr = cfg.get("autolnNThr", 0.05)
+        self.asymlnNThr = cfg.get("asymlnNThr", 0.001)
+        self.ignorelnNThr = cfg.get("ignorelnNThr", 0.001)
+
+        self.autoMCStats = cfg.get("autoMCStats", {"apply": False})
+
+        hist_bins = hist_bins or cfg.get("hist_bins", None)
+        self.hist_binner = Binner(hist_bins)
+        # print(f"Using hist_bins: {self.hist_binner.hist_bins}")
+
+        self.input_files = {}
+        self.shapes = {}
+        self.signal_hists_by_key = {}
+
+    def getBin(self, era, channel, category, return_name=True, return_index=True):
+        name = f"{era}_{self.analysis}_{channel}_{category}"
+        if not return_name and not return_index:
+            raise RuntimeError("Invalid argument combination")
+        if not return_index:
+            return name
+        index = self.bins.index(name)
+        if not return_name:
+            return index
+        return (index, name)
+
+    def cbCopy(self, param_str, process, era, channel, category):
+        bin_idx, bin_name = self.getBin(era, channel, category)
+        return self.cb.cp().mass([param_str]).process([process]).bin([bin_name])
+
+    def ECC(self):
+        return itertools.product(self.eras, self.channels, self.categories)
+
+    def PPECC(self):
+        param_bins = list(self.param_bins.keys())
+        if not self.model.param_dependent_bkg:
+            param_bins.append("*")
+        return itertools.product(
+            self.processes.keys(), param_bins, self.eras, self.channels, self.categories
+        )
+
+    def getInputFile(self, era, model_params):
+        file_name = self.model.getInputFileName(era, model_params)
+        if file_name not in self.input_files:
+            full_file_name = os.path.join(self.input_path, file_name)
+            file = ROOT.TFile.Open(full_file_name, "READ")
+            if file == None:
+                raise RuntimeError(f"Cannot open file {full_file_name}")
+            self.input_files[file_name] = file
+        return file_name, self.input_files[file_name]
+
+    def getMultiValueLnUnc(
+        self, unc, unc_name, process, era, channel, category, model_params
+    ):  # , unc_name=None, unc_scale=None)
+        file_name, file = self.getInputFile(era, model_params)
+        hist_name = f"{channel}/{category}/{process.hist_name}"
+        if unc.getUncertaintyForProcess(process.name) != None:
+            return unc.getUncertaintyForProcess(process.name)
+        elif process.subprocesses:
+            unc_value_tot_down = 0.0
+            unc_value_tot_up = 0.0
+            yield_value_tot = 0.0
+            for subp in process.subprocesses:
+                hist_name = f"{channel}/{category}/{subp}"
+                subhist = file.Get(hist_name)
+                # newhist = self.hist_binner.applyBinning(era, channel, category, model_params, subhist)
+                if subhist == None:
+                    raise RuntimeError(
+                        f"Cannot find histogram {hist_name} in {file.GetName()}"
+                    )
+                axis = subhist.GetXaxis()
+                yield_subproc = subhist.Integral(1, axis.GetNbins() + 1)
+                unc_value = unc.getUncertaintyForProcess(subp)
+                if unc_value != None:
+                    if yield_subproc == 0:
+                        continue
+                    # print(unc_value)
+                    if isinstance(unc_value, dict):
+                        unc_value_tot_up += (
+                            unc_value[UncertaintyScale.Up] * yield_subproc
+                        )
+                        unc_value_tot_down += (
+                            unc_value[UncertaintyScale.Down] * yield_subproc
+                        )
+                    else:
+                        unc_value_tot_up += unc_value * yield_subproc
+                        unc_value_tot_down -= unc_value * yield_subproc
+                    yield_value_tot += yield_subproc
+            if unc_value_tot_up != 0.0 and unc_value_tot_down != 0:
+                return {
+                    UncertaintyScale.Down: unc_value_tot_down / yield_value_tot,
+                    UncertaintyScale.Up: unc_value_tot_up / yield_value_tot,
+                }
+            return None
+        return None
+
+    def getShape(
+        self,
+        process,
+        era,
+        channel,
+        category,
+        model_params,
+        unc_name=None,
+        unc_scale=None,
+    ):
+        file_name, file = self.getInputFile(era, model_params)
+        key = (file_name, process.name, era, channel, category, unc_name, unc_scale)
+        if key not in self.shapes:
+            if process.is_data and (unc_name is not None or unc_scale is not None):
+                raise RuntimeError("Cannot apply uncertainty to the data process")
+            if process.is_asimov_data:
+                hist = None
+                for bkg_proc in self.processes.values():
+                    if bkg_proc.is_background:
+                        if bkg_proc.name not in self.channel_processes[channel]:
+                            continue
+                        bkg_hist = self.getShape(
+                            bkg_proc, era, channel, category, model_params
+                        )
+                        if hist is None:
+                            hist = bkg_hist.Clone()
+                        else:
+                            hist.Add(bkg_hist)
+                if hist is None:
+                    raise RuntimeError("Cannot create asimov data histogram")
+            else:
+                hist_name = f"{channel}/{category}/{process.hist_name}"
+                hists = []
+                if process.subprocesses:
+                    for subp in process.subprocesses:
+                        hist_name = f"{channel}/{category}/{subp}"
+                        if unc_name and unc_scale:
+                            hist_name += f"_{unc_name}_{unc_scale}"
+                        subhist = file.Get(hist_name)
+                        if subhist == None:
+                            raise RuntimeError(
+                                f"Cannot find histogram {hist_name} in {file.GetName()}"
+                            )
+                        hists.append(
+                            self.hist_binner.applyBinning(
+                                era, channel, category, model_params, subhist
+                            )
+                        )
+                else:
+                    if unc_name and unc_scale:
+                        hist_name += f"_{unc_name}_{unc_scale}"
+                    hist = file.Get(hist_name)
+                    if hist == None:
+                        raise RuntimeError(
+                            f"Cannot find histogram {hist_name} in {file.GetName()}"
+                        )
+                    hists.append(
+                        self.hist_binner.applyBinning(
+                            era, channel, category, model_params, hist
+                        )
+                    )
+                if len(hists) == 0:
+                    raise RuntimeError(f"hist list is empty for file {file.GetName()}")
+                hist = hists[0]
+                if len(hists) > 1:
+                    for histy in hists[1:]:
+                        hist.Add(histy)
+
+                hist.SetDirectory(0)
+                if process.scale != 1:
+                    hist.Scale(process.scale)
+
+                if process.is_signal and not (unc_name and unc_scale):
+                    param_str = (
+                        self.model.paramStr(model_params) if model_params else "*"
+                    )
+                    key_sig = (
+                        era,
+                        channel,
+                        category,
+                        (
+                            param_str
+                            if not self.keep_all_signal_hypothesis_into_single_datacard
+                            else "*"
+                        ),
+                    )
+                    self.signal_hists_by_key.setdefault(key_sig, []).append(hist)
+                else:
+                    param_str = (
+                        self.model.paramStr(model_params) if model_params else "*"
+                    )
+                    key_sig = (
+                        era,
+                        channel,
+                        category,
+                        (
+                            param_str
+                            if not self.keep_all_signal_hypothesis_into_single_datacard
+                            else "*"
+                        ),
+                    )
+                    signals = self.signal_hists_by_key.get(key_sig, [])
+                    relevant_bins = getRelevantBins(
+                        era,
+                        channel,
+                        category,
+                        signals,
+                        self.signalFractionForRelevantBins,
+                    )
+                    solution = resolveNegativeBins(
+                        hist,
+                        relevant_bins=relevant_bins,
+                        allow_zero_integral=process.allow_zero_integral,
+                        allow_negative_bins_within_error=process.allow_negative_bins_within_error,
+                        max_n_sigma_for_negative_bins=process.max_n_sigma_for_negative_bins,
+                        allow_negative_integral=process.allow_negative_integral,
+                    )
+
+                    if not solution.accepted:
+                        axis = hist.GetXaxis()
+                        bins_edges = [
+                            str(axis.GetBinLowEdge(n))
+                            for n in range(1, axis.GetNbins() + 2)
+                        ]
+                        bin_values = [
+                            str(hist.GetBinContent(n))
+                            for n in range(1, axis.GetNbins() + 1)
+                        ]
+                        bin_errors = [
+                            str(hist.GetBinError(n))
+                            for n in range(1, axis.GetNbins() + 1)
+                        ]
+                        print(f'bins_edges: [ {", ".join(bins_edges)} ]')
+                        print(f'bin_values: [ {", ".join(bin_values)} ]')
+                        print(f'bin_errors: [ {", ".join(bin_errors)} ]')
+                        raise RuntimeError(
+                            f"Negative bins found in histogram for {channel}/{category}/{process.hist_name}"
+                            + (
+                                f" (syst {unc_name}{unc_scale})"
+                                if unc_name and unc_scale
+                                else ""
+                            )
+                        )
+            self.shapes[key] = hist
+        return self.shapes[key]
+
+    def addProcess(self, proc, era, channel, category):
+        bin_idx, bin_name = self.getBin(era, channel, category)
+        process = self.processes[proc]
+
+        def add(model_params, param_str, process_name):
+            if process.is_data:
+                self.cb.AddObservations(
+                    [param_str],
+                    [self.analysis],
+                    [era],
+                    [channel],
+                    [(bin_idx, bin_name)],
+                )
+            else:
+                self.cb.AddProcesses(
+                    [param_str],
+                    [self.analysis],
+                    [era],
+                    [channel],
+                    [process_name],
+                    [(bin_idx, bin_name)],
+                    process.is_signal,
+                )
+
+            shape = self.getShape(process, era, channel, category, model_params)
+            shape_set = False
+
+            def setShape(p):
+                nonlocal shape_set
+                print(f"Setting shape for {p}")
+                if shape_set:
+                    raise RuntimeError("Shape already set")
+                p.set_shape(shape, True)
+                shape_set = True
+
+            cb_copy = self.cbCopy(param_str, process_name, era, channel, category)
+            if process.is_data:
+                cb_copy.ForEachObs(setShape)
+            else:
+                cb_copy.ForEachProc(setShape)
+
+        if process.is_signal:
+            model_params = process.params
+            param_str = self.model.paramStr(model_params)
+            if self.keep_all_signal_hypothesis_into_single_datacard:
+                actual_proc_name = f"{process.name}_{param_str}"
+                add(model_params, "*", actual_proc_name)
+                self.param_of[("*", actual_proc_name)] = model_params
+                self.base_of[actual_proc_name] = process.name
+            else:
+                actual_proc_name = process.name
+                add(model_params, param_str, actual_proc_name)
+                self.param_of[(param_str, actual_proc_name)] = model_params
+                self.base_of[actual_proc_name] = process.name
+
+        elif self.model.param_dependent_bkg:
+            for signal_proc in self.processes.values():
+                if not signal_proc.is_signal:
                     continue
-                if not process.hasCompatibleModelParams(params, self.model.param_dependent_bkg):
-                    continue
+                model_params = signal_proc.params
+                param_str = (
+                    self.model.paramStr(model_params)
+                    if not self.keep_all_signal_hypothesis_into_single_datacard
+                    else "*"
+                )
+                add(model_params, param_str, proc)
+                self.param_of[(param_str, proc)] = model_params
+                self.base_of[proc] = proc
+        else:
+            add(None, "*", proc)
 
-                nominal_shape = None
-                shapes = {}
-                if unc.needShapes:
-                    nominal_shape = self.getShape(process, era, channel, category, params)
-                    for us in [UncertaintyScale.Up, UncertaintyScale.Down]:
-                        shapes[us] = self.getShape(process, era, channel, category, params, unc_name, us.name)
+    def addUncertainty(self, unc_name):
+        unc = self.uncertainties[unc_name]
+        isMVLnUnc = isinstance(unc, MultiValueLnNUncertainty)
 
-                unc_to_apply = unc.resolveType(nominal_shape, shapes, self.autolnNThr, self.asymlnNThr)
-                if (isMVLnUnc and unc_to_apply.canIgnore(unc_value, self.ignorelnNThr)) or \
-                   (not isMVLnUnc and unc_to_apply.canIgnore(self.ignorelnNThr)):
-                    continue
+        for proc, param_str, era, channel, category in self.PPECC():
+            if proc not in self.channel_processes[channel]:
+                continue
+            process = self.processes[proc]
+            if process.is_data:
+                continue
+            model_params = self.param_bins.get(param_str, None)
+            if isMVLnUnc:
+                unc_value = self.getMultiValueLnUnc(
+                    unc, unc_name, process, era, channel, category, model_params
+                )  # , unc_name=None, unc_scale=None
 
-                systMap = unc_to_apply.valueToMap(unc_value) if isMVLnUnc else unc_to_apply.valueToMap()
-                cb_copy = self.cbCopy(param_str, proc_name, era, channel, category)
-                cb_copy.AddSyst(self.cb, unc_name, unc_to_apply.type.name, systMap)
+            uncApplies = (
+                unc_value != None
+                if isMVLnUnc
+                else unc.appliesTo(process, era, channel, category)
+            )
+            if not uncApplies:
+                continue
+            if not process.hasCompatibleModelParams(
+                model_params, self.model.param_dependent_bkg
+            ):
+                continue
 
-                if unc_to_apply.type == UncertaintyType.shape:
-                    def setShape(syst):
-                        syst.set_shapes(shapes[UncertaintyScale.Up], shapes[UncertaintyScale.Down], nominal_shape)
-                    self.cbCopy(param_str, proc_name, era, channel, category).syst_name([unc_name]).ForEachSyst(setShape)
+            nominal_shape = None
+            shapes = {}
+            if unc.needShapes:
+                model_params = self.param_bins.get(param_str, None)
+                nominal_shape = self.getShape(
+                    self.processes[proc], era, channel, category, model_params
+                )
 
-  def writeDatacards(self, output):
-    os.makedirs(output, exist_ok=True)
+                for unc_scale in [UncertaintyScale.Up, UncertaintyScale.Down]:
+                    shapes[unc_scale] = self.getShape(
+                        self.processes[proc],
+                        era,
+                        channel,
+                        category,
+                        model_params,
+                        unc_name,
+                        unc_scale.name,
+                    )
 
-    if self.keep_all_signal_hypothesis_into_single_datacard:
-      dc_file = os.path.join(output, "datacard_combined_signals.txt")
-      main_shape_file = os.path.join(output, "combined_signals_all.root")
-      self.cb.cp().mass(['*']).WriteDatacard(dc_file, main_shape_file)
+            unc_to_apply = unc.resolveType(
+                nominal_shape, shapes, self.autolnNThr, self.asymlnNThr
+            )
+            can_ignore = (
+                unc_to_apply.canIgnore(unc_value, self.ignorelnNThr)
+                if isMVLnUnc
+                else unc_to_apply.canIgnore(self.ignorelnNThr)
+            )
+            if can_ignore:
+                print(
+                    f"Ignoring uncertainty {unc_name} for {proc} in {era} {channel} {category}"
+                )
+                continue
+            systMap = (
+                unc_to_apply.valueToMap(unc_value)
+                if isMVLnUnc
+                else unc_to_apply.valueToMap()
+            )
+            cb_copy = self.cbCopy(param_str, proc, era, channel, category)
+            cb_copy.AddSyst(self.cb, unc_name, unc_to_apply.type.name, systMap)
+            if unc_to_apply.type == UncertaintyType.shape:
+                shape_set = False
 
-      for subera, subchannel, subcat in self.ECC():
-        tmp_dir = os.path.join(output, subera, subchannel, subcat)
-        os.makedirs(tmp_dir, exist_ok=True)
-        _, bin_name = self.getBin(subera, subchannel, subcat)
-        perbin_dc = os.path.join(tmp_dir, f"datacard_{bin_name}.txt")
-        perbin_root = os.path.join(tmp_dir, f"{bin_name}.root")
-        self.cb.cp().bin([bin_name]).mass(['*']).WriteDatacard(perbin_dc, perbin_root)
+                def setShape(syst):
+                    nonlocal shape_set
+                    print(f"Setting unc shape for {syst}")
+                    if shape_set:
+                        raise RuntimeError("Shape already set")
+                    syst.set_shapes(
+                        shapes[UncertaintyScale.Up],
+                        shapes[UncertaintyScale.Down],
+                        nominal_shape,
+                    )
+                    shape_set = True
 
-      return
+                self.cbCopy(param_str, proc, era, channel, category).syst_name(
+                    [unc_name]
+                ).ForEachSyst(setShape)
 
-    background_names = [n for n,p in self.processes.items() if p.is_background]
-    for proc_name, process in self.processes.items():
-      if not process.is_signal: continue
-      processes = [proc_name] + background_names
-      param_list = [self.model.paramStr(process.params)]
-      if not self.model.param_dependent_bkg:
-        param_list.append('*')
-      dc_file = os.path.join(output, f"datacard_{proc_name}.txt")
-      shape_file = os.path.join(output, f"{proc_name}.root")
+        if self.keep_all_signal_hypothesis_into_single_datacard:
+            for (param_str, proc_name), params in self.param_of.items():
+                for era, channel, category in self.ECC():
+                    base_name = self.base_of.get(proc_name, proc_name)
+                    process = self.processes[base_name]
+                    if process.is_data:
+                        continue
 
-      for subera in self.eras:
-        for subchannel in self.channels:
-          tmp_output = os.path.join(output, subera, subchannel)
-          os.makedirs(tmp_output, exist_ok=True)
-          tmp_dc_file = os.path.join(tmp_output, f"datacard_{proc_name}.txt")
-          tmp_shape_file = shape_file
-          self.cb.cp().era([subera]).channel([subchannel]).mass(param_list).process(processes).WriteDatacard(tmp_dc_file, tmp_shape_file)
+                    if isMVLnUnc:
+                        unc_value = self.getMultiValueLnUnc(
+                            unc, unc_name, process, era, channel, category, params
+                        )
+                    uncApplies = (
+                        (unc_value is not None)
+                        if isMVLnUnc
+                        else unc.appliesTo(process, era, channel, category)
+                    )
+                    if not uncApplies:
+                        continue
+                    if not process.hasCompatibleModelParams(
+                        params, self.model.param_dependent_bkg
+                    ):
+                        continue
 
-      self.cb.cp().mass(param_list).process(processes).WriteDatacard(dc_file, shape_file)
+                    nominal_shape = None
+                    shapes = {}
+                    if unc.needShapes:
+                        nominal_shape = self.getShape(
+                            process, era, channel, category, params
+                        )
+                        for us in [UncertaintyScale.Up, UncertaintyScale.Down]:
+                            shapes[us] = self.getShape(
+                                process,
+                                era,
+                                channel,
+                                category,
+                                params,
+                                unc_name,
+                                us.name,
+                            )
 
+                    unc_to_apply = unc.resolveType(
+                        nominal_shape, shapes, self.autolnNThr, self.asymlnNThr
+                    )
+                    if (
+                        isMVLnUnc
+                        and unc_to_apply.canIgnore(unc_value, self.ignorelnNThr)
+                    ) or (not isMVLnUnc and unc_to_apply.canIgnore(self.ignorelnNThr)):
+                        continue
 
+                    systMap = (
+                        unc_to_apply.valueToMap(unc_value)
+                        if isMVLnUnc
+                        else unc_to_apply.valueToMap()
+                    )
+                    cb_copy = self.cbCopy(param_str, proc_name, era, channel, category)
+                    cb_copy.AddSyst(self.cb, unc_name, unc_to_apply.type.name, systMap)
 
-  def createDatacards(self, output, verbose=1):
-    try:
-      for era, channel, category in self.ECC():
-        for name, p in self.processes.items():
-          if name not in self.channel_processes[channel]:
-              continue
-          if p.is_signal:
-            self.addProcess(name, era, channel, category)
-      for era, channel, category in self.ECC():
-        for name, p in self.processes.items():
-          if name not in self.channel_processes[channel]:
-              continue
-          if not p.is_signal:
-            self.addProcess(name, era, channel, category)
+                    if unc_to_apply.type == UncertaintyType.shape:
 
-      for unc_name in self.uncertainties.keys():
-        print(f"adding uncertainty: {unc_name}")
-        self.addUncertainty(unc_name)
-      if self.autoMCStats["apply"]:
-        self.cb.SetAutoMCStats(self.cb, self.autoMCStats["threshold"], self.autoMCStats["apply_to_signal"],
-                               self.autoMCStats["mode"])
-      if verbose > 0:
-        self.cb.PrintAll()
-      self.writeDatacards(output)
-    finally:
-      for file in self.input_files.values():
-        file.Close()
+                        def setShape(syst):
+                            syst.set_shapes(
+                                shapes[UncertaintyScale.Up],
+                                shapes[UncertaintyScale.Down],
+                                nominal_shape,
+                            )
+
+                        self.cbCopy(
+                            param_str, proc_name, era, channel, category
+                        ).syst_name([unc_name]).ForEachSyst(setShape)
+
+    def writeDatacards(self, output):
+        os.makedirs(output, exist_ok=True)
+
+        if self.keep_all_signal_hypothesis_into_single_datacard:
+            dc_file = os.path.join(output, "datacard_combined_signals.txt")
+            main_shape_file = os.path.join(output, "combined_signals_all.root")
+            self.cb.cp().mass(["*"]).WriteDatacard(dc_file, main_shape_file)
+
+            for subera, subchannel, subcat in self.ECC():
+                tmp_dir = os.path.join(output, subera, subchannel, subcat)
+                os.makedirs(tmp_dir, exist_ok=True)
+                _, bin_name = self.getBin(subera, subchannel, subcat)
+                perbin_dc = os.path.join(tmp_dir, f"datacard_{bin_name}.txt")
+                perbin_root = os.path.join(tmp_dir, f"{bin_name}.root")
+                self.cb.cp().bin([bin_name]).mass(["*"]).WriteDatacard(
+                    perbin_dc, perbin_root
+                )
+
+            return
+
+        background_names = [n for n, p in self.processes.items() if p.is_background]
+        for proc_name, process in self.processes.items():
+            if not process.is_signal:
+                continue
+            processes = [proc_name] + background_names
+            param_list = [self.model.paramStr(process.params)]
+            if not self.model.param_dependent_bkg:
+                param_list.append("*")
+            dc_file = os.path.join(output, f"datacard_{proc_name}.txt")
+            shape_file = os.path.join(output, f"{proc_name}.root")
+
+            for subera in self.eras:
+                for subchannel in self.channels:
+                    tmp_output = os.path.join(output, subera, subchannel)
+                    os.makedirs(tmp_output, exist_ok=True)
+                    tmp_dc_file = os.path.join(tmp_output, f"datacard_{proc_name}.txt")
+                    tmp_shape_file = shape_file
+                    self.cb.cp().era([subera]).channel([subchannel]).mass(
+                        param_list
+                    ).process(processes).WriteDatacard(tmp_dc_file, tmp_shape_file)
+
+            self.cb.cp().mass(param_list).process(processes).WriteDatacard(
+                dc_file, shape_file
+            )
+
+    def createDatacards(self, output, verbose=1):
+        try:
+            for era, channel, category in self.ECC():
+                for name, p in self.processes.items():
+                    if name not in self.channel_processes[channel]:
+                        continue
+                    if p.is_signal:
+                        self.addProcess(name, era, channel, category)
+            for era, channel, category in self.ECC():
+                for name, p in self.processes.items():
+                    if name not in self.channel_processes[channel]:
+                        continue
+                    if not p.is_signal:
+                        self.addProcess(name, era, channel, category)
+
+            for unc_name in self.uncertainties.keys():
+                print(f"adding uncertainty: {unc_name}")
+                self.addUncertainty(unc_name)
+            if self.autoMCStats["apply"]:
+                self.cb.SetAutoMCStats(
+                    self.cb,
+                    self.autoMCStats["threshold"],
+                    self.autoMCStats["apply_to_signal"],
+                    self.autoMCStats["mode"],
+                )
+            if verbose > 0:
+                self.cb.PrintAll()
+            self.writeDatacards(output)
+        finally:
+            for file in self.input_files.values():
+                file.Close()

--- a/dc_make/process.py
+++ b/dc_make/process.py
@@ -1,87 +1,138 @@
 from ..common.param_parse import extractParameters, applyParameters, parameterListToDict
 
+
 class Process:
-  def __init__(self, name, hist_name, is_signal=False, is_data=False, is_asimov_data=False, scale=1, params=None, subprocesses=None, allow_zero_integral=False, allow_negative_bins_within_error=False, max_n_sigma_for_negative_bins=1, allow_negative_integral=False, channels=[]):
-    self.name = name
-    self.hist_name = hist_name
-    self.is_signal = is_signal
-    self.is_data = is_data
-    self.is_asimov_data = is_asimov_data
-    self.is_background = not (is_signal or is_data)
-    self.scale=scale
-    self.params = params
-    self.subprocesses = subprocesses
-    self.allow_zero_integral = allow_zero_integral
-    self.allow_negative_bins_within_error = allow_negative_bins_within_error
-    self.max_n_sigma_for_negative_bins = max_n_sigma_for_negative_bins
-    self.allow_negative_integral = allow_negative_integral
-    self.channels = channels
-    if is_data and is_signal:
-      raise RuntimeError("Data and signal flags cannot be set simultaneously")
-    if is_asimov_data and not is_data:
-      raise RuntimeError("Asimov data flag can only be set for data processes")
+    def __init__(
+        self,
+        name,
+        hist_name,
+        is_signal=False,
+        is_data=False,
+        is_asimov_data=False,
+        scale=1,
+        params=None,
+        subprocesses=None,
+        allow_zero_integral=False,
+        allow_negative_bins_within_error=False,
+        max_n_sigma_for_negative_bins=1,
+        allow_negative_integral=False,
+        channels=[],
+    ):
+        self.name = name
+        self.hist_name = hist_name
+        self.is_signal = is_signal
+        self.is_data = is_data
+        self.is_asimov_data = is_asimov_data
+        self.is_background = not (is_signal or is_data)
+        self.scale = scale
+        self.params = params
+        self.subprocesses = subprocesses
+        self.allow_zero_integral = allow_zero_integral
+        self.allow_negative_bins_within_error = allow_negative_bins_within_error
+        self.max_n_sigma_for_negative_bins = max_n_sigma_for_negative_bins
+        self.allow_negative_integral = allow_negative_integral
+        self.channels = channels
+        if is_data and is_signal:
+            raise RuntimeError("Data and signal flags cannot be set simultaneously")
+        if is_asimov_data and not is_data:
+            raise RuntimeError("Asimov data flag can only be set for data processes")
 
-    if is_signal:
-      self.type = "signal"
-    elif is_data:
-      self.type = "data"
-    else:
-      self.type = "background"
+        if is_signal:
+            self.type = "signal"
+        elif is_data:
+            self.type = "data"
+        else:
+            self.type = "background"
 
-  def __str__(self):
-    str_rep =  f"Process({self.name}, type={self.type}, subprocesses={self.subprocesses}"
-    if self.is_signal:
-      str_rep += f", params={self.params}"
-    str_rep += ")"
-    return str_rep
+    def __str__(self):
+        str_rep = (
+            f"Process({self.name}, type={self.type}, subprocesses={self.subprocesses}"
+        )
+        if self.is_signal:
+            str_rep += f", params={self.params}"
+        str_rep += ")"
+        return str_rep
 
-  def hasCompatibleModelParams(self, model_params, param_dependent_bkg):
-    if self.is_data or self.is_background:
-      if model_params and not param_dependent_bkg:
-        return False
-      return True
-    if not model_params:
-      return False
-    for param, value in self.params.items():
-      if model_params[param] != value:
-        return False
-    return True
+    def hasCompatibleModelParams(self, model_params, param_dependent_bkg):
+        if self.is_data or self.is_background:
+            if model_params and not param_dependent_bkg:
+                return False
+            return True
+        if not model_params:
+            return False
+        for param, value in self.params.items():
+            if model_params[param] != value:
+                return False
+        return True
 
-  @staticmethod
-  def fromConfig(entry, model):
-    if type(entry) == str:
-      return [ Process(entry, entry) ]
-    if type(entry) != dict:
-      raise RuntimeError("Invalid entry type")
-    base_name = entry["process"]
-    base_hist_name = entry.get("hist_name", base_name)
-    is_signal = entry.get("is_signal", False)
-    is_data = entry.get("is_data", False)
-    is_asimov_data = entry.get("is_asimov_data", False)
-    subprocesses = entry.get("subprocesses", [])
-    scale = entry.get("scale", 1)
-    allow_zero_integral = entry.get("allow_zero_integral", False)
-    allow_negative_integral = entry.get("allow_negative_integral", False)
-    allow_negative_bins_within_error = entry.get("allow_negative_bins_within_error", False)
-    max_n_sigma_for_negative_bins = entry.get("max_n_sigma_for_negative_bins", 1)
-    channels = entry.get("channels", [])
-    if type(scale) == str:
-      scale = eval(scale)
-    if 'param_values' not in entry:
-      if is_signal and len(model.parameters) > 0:
-        raise RuntimeError("Signal process must have parameter values")
-      # return [ Process(base_name, base_hist_name, is_signal=is_signal, is_data=is_data, is_asimov_data=is_asimov_data,scale=scale,subprocesses=subprocesses,  allow_zero_integral=allow_zero_integral, allow_negative_bins_within_error=allow_negative_bins_within_error, max_n_sigma_for_negative_bins=max_n_sigma_for_negative_bins, allow_negative_integral=allow_negative_integral )]
-      return [ Process(base_name, base_hist_name, is_signal=is_signal, is_data=is_data, is_asimov_data=is_asimov_data,scale=scale,subprocesses=subprocesses,  allow_zero_integral=allow_zero_integral, allow_negative_bins_within_error=allow_negative_bins_within_error, max_n_sigma_for_negative_bins=max_n_sigma_for_negative_bins, allow_negative_integral=allow_negative_integral, channels=channels )]
+    @staticmethod
+    def fromConfig(entry, model):
+        if type(entry) == str:
+            return [Process(entry, entry)]
+        if type(entry) != dict:
+            raise RuntimeError("Invalid entry type")
+        base_name = entry["process"]
+        base_hist_name = entry.get("hist_name", base_name)
+        is_signal = entry.get("is_signal", False)
+        is_data = entry.get("is_data", False)
+        is_asimov_data = entry.get("is_asimov_data", False)
+        subprocesses = entry.get("subprocesses", [])
+        scale = entry.get("scale", 1)
+        allow_zero_integral = entry.get("allow_zero_integral", False)
+        allow_negative_integral = entry.get("allow_negative_integral", False)
+        allow_negative_bins_within_error = entry.get(
+            "allow_negative_bins_within_error", False
+        )
+        max_n_sigma_for_negative_bins = entry.get("max_n_sigma_for_negative_bins", 1)
+        channels = entry.get("channels", [])
+        if type(scale) == str:
+            scale = eval(scale)
+        if "param_values" not in entry:
+            if is_signal and len(model.parameters) > 0:
+                raise RuntimeError("Signal process must have parameter values")
+            # return [ Process(base_name, base_hist_name, is_signal=is_signal, is_data=is_data, is_asimov_data=is_asimov_data,scale=scale,subprocesses=subprocesses,  allow_zero_integral=allow_zero_integral, allow_negative_bins_within_error=allow_negative_bins_within_error, max_n_sigma_for_negative_bins=max_n_sigma_for_negative_bins, allow_negative_integral=allow_negative_integral )]
+            return [
+                Process(
+                    base_name,
+                    base_hist_name,
+                    is_signal=is_signal,
+                    is_data=is_data,
+                    is_asimov_data=is_asimov_data,
+                    scale=scale,
+                    subprocesses=subprocesses,
+                    allow_zero_integral=allow_zero_integral,
+                    allow_negative_bins_within_error=allow_negative_bins_within_error,
+                    max_n_sigma_for_negative_bins=max_n_sigma_for_negative_bins,
+                    allow_negative_integral=allow_negative_integral,
+                    channels=channels,
+                )
+            ]
 
-    parameters = model.parameters if is_signal else extractParameters(base_name)
-    param_values = entry["param_values"]
-    if type(param_values) != list or len(param_values) == 0:
-      raise RuntimeError("Invalid parameter values")
-    processes = []
-    for param_entry in param_values:
-      param_dict = parameterListToDict(parameters, param_entry)
-      name = applyParameters(base_name, param_dict)
-      hist_name = applyParameters(base_hist_name, param_dict)
-      # processes.append(Process(name, hist_name, is_signal=is_signal, is_data=is_data, is_asimov_data=is_asimov_data,scale=scale,subprocesses=subprocesses,  allow_zero_integral=allow_zero_integral, allow_negative_bins_within_error=allow_negative_bins_within_error, max_n_sigma_for_negative_bins=max_n_sigma_for_negative_bins, allow_negative_integral=allow_negative_integral, params=param_dict))
-      processes.append(Process(name, hist_name, is_signal=is_signal, is_data=is_data, is_asimov_data=is_asimov_data,scale=scale,subprocesses=subprocesses,  allow_zero_integral=allow_zero_integral, allow_negative_bins_within_error=allow_negative_bins_within_error, max_n_sigma_for_negative_bins=max_n_sigma_for_negative_bins, allow_negative_integral=allow_negative_integral, params=param_dict, channels=channels ))
-    return processes
+        parameters = model.parameters if is_signal else extractParameters(base_name)
+        param_values = entry["param_values"]
+        if type(param_values) != list or len(param_values) == 0:
+            raise RuntimeError("Invalid parameter values")
+        processes = []
+        for param_entry in param_values:
+            param_dict = parameterListToDict(parameters, param_entry)
+            name = applyParameters(base_name, param_dict)
+            hist_name = applyParameters(base_hist_name, param_dict)
+            # processes.append(Process(name, hist_name, is_signal=is_signal, is_data=is_data, is_asimov_data=is_asimov_data,scale=scale,subprocesses=subprocesses,  allow_zero_integral=allow_zero_integral, allow_negative_bins_within_error=allow_negative_bins_within_error, max_n_sigma_for_negative_bins=max_n_sigma_for_negative_bins, allow_negative_integral=allow_negative_integral, params=param_dict))
+            processes.append(
+                Process(
+                    name,
+                    hist_name,
+                    is_signal=is_signal,
+                    is_data=is_data,
+                    is_asimov_data=is_asimov_data,
+                    scale=scale,
+                    subprocesses=subprocesses,
+                    allow_zero_integral=allow_zero_integral,
+                    allow_negative_bins_within_error=allow_negative_bins_within_error,
+                    max_n_sigma_for_negative_bins=max_n_sigma_for_negative_bins,
+                    allow_negative_integral=allow_negative_integral,
+                    params=param_dict,
+                    channels=channels,
+                )
+            )
+        return processes

--- a/dc_make/uncertainty.py
+++ b/dc_make/uncertainty.py
@@ -4,306 +4,379 @@ import re
 from enum import Enum
 
 from ..common.tools import importROOT
+
 ROOT = importROOT()
 
 from CombineHarvester.CombineTools.ch import SystMap
 
+
 class UncertaintyScale(Enum):
-  Up = 1
-  Down = -1
+    Up = 1
+    Down = -1
+
 
 class UncertaintyType(Enum):
-  auto = 0
-  lnN = 1
-  shape = 2
+    auto = 0
+    lnN = 1
+    shape = 2
+
 
 class Uncertainty:
-  def __init__(self, name, processes=None, eras=None, channels=None, categories=None, hasMultipleValues=False):
-    self.name = name
-    self.processes = processes
-    self.eras = eras
-    self.channels = channels
-    self.categories = categories
-    self.hasMultipleValues=hasMultipleValues
+    def __init__(
+        self,
+        name,
+        processes=None,
+        eras=None,
+        channels=None,
+        categories=None,
+        hasMultipleValues=False,
+    ):
+        self.name = name
+        self.processes = processes
+        self.eras = eras
+        self.channels = channels
+        self.categories = categories
+        self.hasMultipleValues = hasMultipleValues
 
-  def appliesTo(self, process, era, channel, category):
-    match_subprocess = any(map(lambda p: Uncertainty.hasMatch(p, self.processes), process.subprocesses)) if process.subprocesses else False
-    return  (Uncertainty.hasMatch(process.name, self.processes) or match_subprocess) \
-        and Uncertainty.hasMatch(era, self.eras) \
-        and Uncertainty.hasMatch(channel, self.channels) \
-        and Uncertainty.hasMatch(category, self.categories)
+    def appliesTo(self, process, era, channel, category):
+        match_subprocess = (
+            any(
+                map(
+                    lambda p: Uncertainty.hasMatch(p, self.processes),
+                    process.subprocesses,
+                )
+            )
+            if process.subprocesses
+            else False
+        )
+        return (
+            (Uncertainty.hasMatch(process.name, self.processes) or match_subprocess)
+            and Uncertainty.hasMatch(era, self.eras)
+            and Uncertainty.hasMatch(channel, self.channels)
+            and Uncertainty.hasMatch(category, self.categories)
+        )
 
-  def resolveType(self, nominal_shape, shape_variations, auto_lnN_threshold, asym_value_threshold):
-    return self
+    def resolveType(
+        self, nominal_shape, shape_variations, auto_lnN_threshold, asym_value_threshold
+    ):
+        return self
 
-  @staticmethod
-  def fitFlat(histogram):
-    def constantFunction(x,par):
-      return par[0]
-    fit_func = ROOT.TF1("fit_func", constantFunction, 0, 10, 1)
-    fit_func.SetParameter(0, 1.0)
-    histogram.Fit(fit_func, "nq")
-    chi2 = fit_func.GetChisquare()
-    ndf = fit_func.GetNDF()
-    p_value = ROOT.TMath.Prob(chi2, ndf)
-    fit_param = fit_func.GetParameter(0)
-    fit_param_error = fit_func.GetParError(0)
-    return chi2, p_value, fit_param, fit_param_error
+    @staticmethod
+    def fitFlat(histogram):
+        def constantFunction(x, par):
+            return par[0]
 
-  @staticmethod
-  def haveCompatibleShapes(hist_a, hist_b, p_thr):
-    hist_b = hist_b.Clone()
-    hist_b.Divide(hist_a)
-    _, p_value, _, _ = Uncertainty.fitFlat(hist_b)
-    return p_value > p_thr
+        fit_func = ROOT.TF1("fit_func", constantFunction, 0, 10, 1)
+        fit_func.SetParameter(0, 1.0)
+        histogram.Fit(fit_func, "nq")
+        chi2 = fit_func.GetChisquare()
+        ndf = fit_func.GetNDF()
+        p_value = ROOT.TMath.Prob(chi2, ndf)
+        fit_param = fit_func.GetParameter(0)
+        fit_param_error = fit_func.GetParError(0)
+        return chi2, p_value, fit_param, fit_param_error
 
-  @staticmethod
-  def hasMatch(value, patterns):
-    if len(patterns) == 0:
-      return True
-    for pattern in patterns:
-      if pattern[0] == '^':
-        if re.match(pattern, value):
-          return True
-      elif value == pattern:
-        return True
-    return False
+    @staticmethod
+    def haveCompatibleShapes(hist_a, hist_b, p_thr):
+        hist_b = hist_b.Clone()
+        hist_b.Divide(hist_a)
+        _, p_value, _, _ = Uncertainty.fitFlat(hist_b)
+        return p_value > p_thr
 
-  @staticmethod
-  def fromConfig(entry):
-    name = entry["name"]
-    # print(name)
-    unc_type = UncertaintyType[entry["type"]]
-    hasMultipleValues = entry.get("hasMultipleValues", False)
-    def getPatternList(key, entry=entry):
-        if key not in entry:
-            return []
-        v = entry[key]
-        if type(v) == str:
-            return [v]
-        return v
+    @staticmethod
+    def hasMatch(value, patterns):
+        if len(patterns) == 0:
+            return True
+        for pattern in patterns:
+            if pattern[0] == "^":
+                if re.match(pattern, value):
+                    return True
+            elif value == pattern:
+                return True
+        return False
 
-    args = {}
-    for key in ["processes", "eras", "channels", "categories"]:
-        args[key] = getPatternList(key)
+    @staticmethod
+    def fromConfig(entry):
+        name = entry["name"]
+        # print(name)
+        unc_type = UncertaintyType[entry["type"]]
+        hasMultipleValues = entry.get("hasMultipleValues", False)
 
-    if unc_type == UncertaintyType.lnN:
-      value = entry.get("value")
-      # print(value)
-      if value is None:
-        raise RuntimeError("Uncertainty must have a value")
-      if isinstance(value, (float, int)):
-        value = float(value)
-        unc = LnNUncertainty(name, value, **args)
-        unc.checkValue()
-      elif isinstance(value, list) and hasMultipleValues:
-        multi_values = {}
+        def getPatternList(key, entry=entry):
+            if key not in entry:
+                return []
+            v = entry[key]
+            if type(v) == str:
+                return [v]
+            return v
 
-        for sub_entry in value:
-          key_value = (tuple(getPatternList("processes", sub_entry)),
-                  tuple(getPatternList("eras", sub_entry)),
-                  tuple(getPatternList("channels", sub_entry)),
-                  tuple(getPatternList("categories", sub_entry)))
-          for key in ["processes", "eras", "channels", "categories"]:
-            args[key] = getPatternList(key,sub_entry)
-          multi_values[key_value] = sub_entry["value"]
-          if isinstance(sub_entry["value"], list) and len(sub_entry["value"]) == 2:
-            multi_values[key_value] = {UncertaintyScale.Down: sub_entry["value"][0], UncertaintyScale.Up: sub_entry["value"][1]}
-        unc = MultiValueLnNUncertainty(name, multi_values,**args)
-        unc.checkValue()
+        args = {}
+        for key in ["processes", "eras", "channels", "categories"]:
+            args[key] = getPatternList(key)
 
-      elif isinstance(value, list) and len(value) == 2 and not hasMultipleValues:
-        value = {UncertaintyScale.Down: value[0], UncertaintyScale.Up: value[1]}
-        unc = LnNUncertainty(name, value, **args)
-        unc.checkValue()
-      elif isinstance(value, dict):
-        unc = LnNUncertainty(name, value, **args)
-        unc.checkValue()
-      else:
-        raise RuntimeError("Invalid lnN uncertainty value")
-    elif unc_type == UncertaintyType.shape:
-      unc = ShapeUncertainty(name, **args)
-    elif unc_type == UncertaintyType.auto:
-      unc = AutoUncertainty(name, **args)
-    else:
-      raise RuntimeError("Invalid uncertainty type")
+        if unc_type == UncertaintyType.lnN:
+            value = entry.get("value")
+            # print(value)
+            if value is None:
+                raise RuntimeError("Uncertainty must have a value")
+            if isinstance(value, (float, int)):
+                value = float(value)
+                unc = LnNUncertainty(name, value, **args)
+                unc.checkValue()
+            elif isinstance(value, list) and hasMultipleValues:
+                multi_values = {}
 
-    return unc
+                for sub_entry in value:
+                    key_value = (
+                        tuple(getPatternList("processes", sub_entry)),
+                        tuple(getPatternList("eras", sub_entry)),
+                        tuple(getPatternList("channels", sub_entry)),
+                        tuple(getPatternList("categories", sub_entry)),
+                    )
+                    for key in ["processes", "eras", "channels", "categories"]:
+                        args[key] = getPatternList(key, sub_entry)
+                    multi_values[key_value] = sub_entry["value"]
+                    if (
+                        isinstance(sub_entry["value"], list)
+                        and len(sub_entry["value"]) == 2
+                    ):
+                        multi_values[key_value] = {
+                            UncertaintyScale.Down: sub_entry["value"][0],
+                            UncertaintyScale.Up: sub_entry["value"][1],
+                        }
+                unc = MultiValueLnNUncertainty(name, multi_values, **args)
+                unc.checkValue()
+
+            elif isinstance(value, list) and len(value) == 2 and not hasMultipleValues:
+                value = {UncertaintyScale.Down: value[0], UncertaintyScale.Up: value[1]}
+                unc = LnNUncertainty(name, value, **args)
+                unc.checkValue()
+            elif isinstance(value, dict):
+                unc = LnNUncertainty(name, value, **args)
+                unc.checkValue()
+            else:
+                raise RuntimeError("Invalid lnN uncertainty value")
+        elif unc_type == UncertaintyType.shape:
+            unc = ShapeUncertainty(name, **args)
+        elif unc_type == UncertaintyType.auto:
+            unc = AutoUncertainty(name, **args)
+        else:
+            raise RuntimeError("Invalid uncertainty type")
+
+        return unc
 
 
 class LnNUncertainty(Uncertainty):
-  def __init__(self, name, value, **kwargs):
-    super().__init__(name, **kwargs)
-    self.value = value
+    def __init__(self, name, value, **kwargs):
+        super().__init__(name, **kwargs)
+        self.value = value
 
-  @property
-  def type(self):
-    return UncertaintyType.lnN
+    @property
+    def type(self):
+        return UncertaintyType.lnN
 
-  @property
-  def needShapes(self):
-    return False
+    @property
+    def needShapes(self):
+        return False
 
-  def canIgnore(self, value_thr):
-    if type(self.value) == float:
-      return abs(self.value) < value_thr
-    return abs(self.value[UncertaintyScale.Up]) < value_thr and abs(self.value[UncertaintyScale.Down]) < value_thr
+    def canIgnore(self, value_thr):
+        if type(self.value) == float:
+            return abs(self.value) < value_thr
+        return (
+            abs(self.value[UncertaintyScale.Up]) < value_thr
+            and abs(self.value[UncertaintyScale.Down]) < value_thr
+        )
 
-  def checkValue(self, raise_error=True):
-    pass_zero_check = True
-    pass_sign_check = True
-    pass_magnitude_check = True
-    if type(self.value) == float:
-
-      if self.value == 0:
-        pass_zero_check = False
-      if abs(self.value) >= 1:
-        pass_magnitude_check = False
-    elif type(self.value) == dict:
-      if self.value[UncertaintyScale.Down] == 0 or self.value[UncertaintyScale.Up] == 0:
-        pass_zero_check = False
-      if self.value[UncertaintyScale.Down] * self.value[UncertaintyScale.Up] > 0:
-        pass_sign_check = False
-      if abs(self.value[UncertaintyScale.Down]) >= 1 or abs(self.value[UncertaintyScale.Up]) >= 1:
-        pass_magnitude_check = False
-    else:
-      raise RuntimeError("Invalid lnN uncertainty value")
-
-    if not pass_zero_check and raise_error:
-      raise RuntimeError(f"Value of lnN uncertainty {self.name} cannot be zero")
-    if not pass_sign_check and raise_error:
-      raise RuntimeError(f"Up/down values of lnN uncertainty {self.name} must have opposite signs")
-    if not pass_magnitude_check and raise_error:
-      raise RuntimeError(f"Value of lnN uncertainty {self.name} must be less than 100%")
-    return pass_zero_check, pass_sign_check, pass_magnitude_check
-
-  def valueToMap(self, digits=3):
-    if type(self.value) == float:
-      value = round(1 + self.value, digits)
-    else:
-      v_down = round(1 + self.value[UncertaintyScale.Down], digits)
-      v_up = round(1 + self.value[UncertaintyScale.Up], digits)
-      value = (v_down, v_up)
-    return SystMap()(value)
-
-class MultiValueLnNUncertainty(Uncertainty):
-  def __init__(self, name, values, **kwargs):
-      super().__init__(name, **kwargs)
-      # self.name = name
-      self.values = values
-
-  @property
-  def type(self):
-    return UncertaintyType.lnN
-
-  @property
-  def needShapes(self):
-    return False
-
-  @classmethod
-  def fromConfig(cls, cfg):
-      name = cfg['name']
-      values = cfg['value']
-      return cls(name, values)
-
-  def canIgnore(self, unc_value, value_thr):
-    if type(unc_value) == float:
-      return abs(unc_value) < value_thr
-    return abs(unc_value[UncertaintyScale.Up]) < value_thr and abs(unc_value[UncertaintyScale.Down]) < value_thr
-
-
-  def checkValue(self):
-      for key in self.values.keys():
-        processes, eras, channels, categories = key
-        value = self.values[key]
+    def checkValue(self, raise_error=True):
         pass_zero_check = True
         pass_sign_check = True
         pass_magnitude_check = True
-        if type(value) == float:
+        if type(self.value) == float:
 
-          if value == 0:
-            pass_zero_check = False
-          if abs(value) >= 1:
-            pass_magnitude_check = False
-        elif type(value) == dict:
-          if value[UncertaintyScale.Down] == 0 or value[UncertaintyScale.Up] == 0:
-            pass_zero_check = False
-          if value[UncertaintyScale.Down] * value[UncertaintyScale.Up] > 0:
-            pass_sign_check = False
-          if abs(value[UncertaintyScale.Down]) >= 1 or abs(value[UncertaintyScale.Up]) >= 1:
-            pass_magnitude_check = False
+            if self.value == 0:
+                pass_zero_check = False
+            if abs(self.value) >= 1:
+                pass_magnitude_check = False
+        elif type(self.value) == dict:
+            if (
+                self.value[UncertaintyScale.Down] == 0
+                or self.value[UncertaintyScale.Up] == 0
+            ):
+                pass_zero_check = False
+            if self.value[UncertaintyScale.Down] * self.value[UncertaintyScale.Up] > 0:
+                pass_sign_check = False
+            if (
+                abs(self.value[UncertaintyScale.Down]) >= 1
+                or abs(self.value[UncertaintyScale.Up]) >= 1
+            ):
+                pass_magnitude_check = False
         else:
-          raise RuntimeError("Invalid lnN uncertainty value")
-        # if not isinstance(value, (int, float)):
-        #     raise ValueError(f"Invalid uncertainty value: {value}. Must be numeric.")
-        # if not isinstance(processes, tuple) or not all(isinstance(p, str) for p in processes):
-        #     raise ValueError(f"Invalid processes list: {processes}. Must be a list of strings.")
+            raise RuntimeError("Invalid lnN uncertainty value")
 
-  def getUncertaintyForProcess(self, process):
-    for key in self.values.keys():
-      processes, eras, channels, categories = key
-      if process in processes:
-        return self.values[key]
-    return None
+        if not pass_zero_check and raise_error:
+            raise RuntimeError(f"Value of lnN uncertainty {self.name} cannot be zero")
+        if not pass_sign_check and raise_error:
+            raise RuntimeError(
+                f"Up/down values of lnN uncertainty {self.name} must have opposite signs"
+            )
+        if not pass_magnitude_check and raise_error:
+            raise RuntimeError(
+                f"Value of lnN uncertainty {self.name} must be less than 100%"
+            )
+        return pass_zero_check, pass_sign_check, pass_magnitude_check
 
-  def valueToMap(self, unc_value, digits=3):
-    if type(unc_value) == float:
-      value = round(1 + unc_value, digits)
-    else:
-      v_down = round(1 + unc_value[UncertaintyScale.Down], digits)
-      v_up = round(1 + unc_value[UncertaintyScale.Up], digits)
-      value = (v_down, v_up)
-    return SystMap()(value)
+    def valueToMap(self, digits=3):
+        if type(self.value) == float:
+            value = round(1 + self.value, digits)
+        else:
+            v_down = round(1 + self.value[UncertaintyScale.Down], digits)
+            v_up = round(1 + self.value[UncertaintyScale.Up], digits)
+            value = (v_down, v_up)
+        return SystMap()(value)
+
+
+class MultiValueLnNUncertainty(Uncertainty):
+    def __init__(self, name, values, **kwargs):
+        super().__init__(name, **kwargs)
+        # self.name = name
+        self.values = values
+
+    @property
+    def type(self):
+        return UncertaintyType.lnN
+
+    @property
+    def needShapes(self):
+        return False
+
+    @classmethod
+    def fromConfig(cls, cfg):
+        name = cfg["name"]
+        values = cfg["value"]
+        return cls(name, values)
+
+    def canIgnore(self, unc_value, value_thr):
+        if type(unc_value) == float:
+            return abs(unc_value) < value_thr
+        return (
+            abs(unc_value[UncertaintyScale.Up]) < value_thr
+            and abs(unc_value[UncertaintyScale.Down]) < value_thr
+        )
+
+    def checkValue(self):
+        for key in self.values.keys():
+            processes, eras, channels, categories = key
+            value = self.values[key]
+            pass_zero_check = True
+            pass_sign_check = True
+            pass_magnitude_check = True
+            if type(value) == float:
+
+                if value == 0:
+                    pass_zero_check = False
+                if abs(value) >= 1:
+                    pass_magnitude_check = False
+            elif type(value) == dict:
+                if value[UncertaintyScale.Down] == 0 or value[UncertaintyScale.Up] == 0:
+                    pass_zero_check = False
+                if value[UncertaintyScale.Down] * value[UncertaintyScale.Up] > 0:
+                    pass_sign_check = False
+                if (
+                    abs(value[UncertaintyScale.Down]) >= 1
+                    or abs(value[UncertaintyScale.Up]) >= 1
+                ):
+                    pass_magnitude_check = False
+            else:
+                raise RuntimeError("Invalid lnN uncertainty value")
+            # if not isinstance(value, (int, float)):
+            #     raise ValueError(f"Invalid uncertainty value: {value}. Must be numeric.")
+            # if not isinstance(processes, tuple) or not all(isinstance(p, str) for p in processes):
+            #     raise ValueError(f"Invalid processes list: {processes}. Must be a list of strings.")
+
+    def getUncertaintyForProcess(self, process):
+        for key in self.values.keys():
+            processes, eras, channels, categories = key
+            if process in processes:
+                return self.values[key]
+        return None
+
+    def valueToMap(self, unc_value, digits=3):
+        if type(unc_value) == float:
+            value = round(1 + unc_value, digits)
+        else:
+            v_down = round(1 + unc_value[UncertaintyScale.Down], digits)
+            v_up = round(1 + unc_value[UncertaintyScale.Up], digits)
+            value = (v_down, v_up)
+        return SystMap()(value)
 
 
 class ShapeUncertainty(Uncertainty):
-  @property
-  def type(self):
-    return UncertaintyType.shape
+    @property
+    def type(self):
+        return UncertaintyType.shape
 
-  @property
-  def needShapes(self):
-    return True
+    @property
+    def needShapes(self):
+        return True
 
-  def canIgnore(self, value_thr):
-    return False
+    def canIgnore(self, value_thr):
+        return False
 
-  def valueToMap(self, digits=3):
-    return SystMap()(1.0)
+    def valueToMap(self, digits=3):
+        return SystMap()(1.0)
+
 
 class AutoUncertainty(Uncertainty):
-  @property
-  def needShapes(self):
-    return True
+    @property
+    def needShapes(self):
+        return True
 
-  def canIgnore(self, value_thr):
-    raise RuntimeError("Uncertainty type is not resolved yet")
+    def canIgnore(self, value_thr):
+        raise RuntimeError("Uncertainty type is not resolved yet")
 
-  def valueToMap(self, digits=3):
-    raise RuntimeError("Uncertainty type is not resolved yet")
+    def valueToMap(self, digits=3):
+        raise RuntimeError("Uncertainty type is not resolved yet")
 
-  def resolveType(self, nominal_shape, shape_variations, auto_lnN_threshold, asym_value_threshold):
-    nominal_shape = nominal_shape.Clone()
-    for n in range(0, nominal_shape.GetNbinsX() + 2):
-      nominal_shape.SetBinError(n, 0)
-    all_compatible = True
-    for unc_scale in [ UncertaintyScale.Up, UncertaintyScale.Down ]:
-      if not Uncertainty.haveCompatibleShapes(nominal_shape, shape_variations[unc_scale], auto_lnN_threshold):
-        all_compatible = False
-        break
-    args = { "processes": self.processes, "eras": self.eras, "channels": self.channels, "categories": self.categories }
-    if all_compatible:
-      unc_value = {}
-      nominal_integral = nominal_shape.Integral()
-      for unc_scale in [ UncertaintyScale.Up, UncertaintyScale.Down ]:
-        scaled_integral = shape_variations[unc_scale].Integral()
-        unc_value[unc_scale] = (scaled_integral - nominal_integral) / nominal_integral
-      unc = LnNUncertainty(self.name, unc_value, **args)
-      pass_zero_check, pass_sign_check, pass_magnitude_check = unc.checkValue(raise_error=False)
-      if pass_sign_check and pass_magnitude_check:
-        delta = abs(unc.value[UncertaintyScale.Up]) - abs(unc.value[UncertaintyScale.Down])
-        if abs(delta) <= asym_value_threshold:
-          max_value = max(abs(unc.value[UncertaintyScale.Up]), abs(unc.value[UncertaintyScale.Down]))
-          unc.value = math.copysign(max_value, unc.value[UncertaintyScale.Up])
-        return unc
-    return ShapeUncertainty(self.name, **args)
+    def resolveType(
+        self, nominal_shape, shape_variations, auto_lnN_threshold, asym_value_threshold
+    ):
+        nominal_shape = nominal_shape.Clone()
+        for n in range(0, nominal_shape.GetNbinsX() + 2):
+            nominal_shape.SetBinError(n, 0)
+        all_compatible = True
+        for unc_scale in [UncertaintyScale.Up, UncertaintyScale.Down]:
+            if not Uncertainty.haveCompatibleShapes(
+                nominal_shape, shape_variations[unc_scale], auto_lnN_threshold
+            ):
+                all_compatible = False
+                break
+        args = {
+            "processes": self.processes,
+            "eras": self.eras,
+            "channels": self.channels,
+            "categories": self.categories,
+        }
+        if all_compatible:
+            unc_value = {}
+            nominal_integral = nominal_shape.Integral()
+            for unc_scale in [UncertaintyScale.Up, UncertaintyScale.Down]:
+                scaled_integral = shape_variations[unc_scale].Integral()
+                unc_value[unc_scale] = (
+                    scaled_integral - nominal_integral
+                ) / nominal_integral
+            unc = LnNUncertainty(self.name, unc_value, **args)
+            pass_zero_check, pass_sign_check, pass_magnitude_check = unc.checkValue(
+                raise_error=False
+            )
+            if pass_sign_check and pass_magnitude_check:
+                delta = abs(unc.value[UncertaintyScale.Up]) - abs(
+                    unc.value[UncertaintyScale.Down]
+                )
+                if abs(delta) <= asym_value_threshold:
+                    max_value = max(
+                        abs(unc.value[UncertaintyScale.Up]),
+                        abs(unc.value[UncertaintyScale.Down]),
+                    )
+                    unc.value = math.copysign(max_value, unc.value[UncertaintyScale.Up])
+                return unc
+        return ShapeUncertainty(self.name, **args)


### PR DESCRIPTION
Pure black output (default settings, no config file in the repo), scoped to the five files that are not already black-clean and that the HistRebin/limit- plotting PR touches. No functional change: black's default safe mode verifies the AST is unchanged.

This lands first so that PR's diff shows only its real changes.